### PR TITLE
Add workaround for conditional spanning multiple sections

### DIFF
--- a/license-validate.py
+++ b/license-validate.py
@@ -35,9 +35,14 @@ def read_from_spec(filename):
     with specfile.sections() as sections:
         for section in sections:
             if section.name.startswith("package"):
-                with specfile.tags(section) as tags:
-                    if 'License' in tags:
-                        result.append(tags.license.expanded_value)
+                # Workaround for conditionals spanning multiple sections:
+                # https://github.com/packit/specfile/issues/365
+                try:
+                    with specfile.tags(section) as tags:
+                        if 'License' in tags:
+                            result.append(tags.license.expanded_value)
+                except Exception:
+                    print(f"Warning: Could not parse section '{section.id}', skipping.")
     return result
 
 class T(Transformer):

--- a/license-validate.py
+++ b/license-validate.py
@@ -41,7 +41,7 @@ def read_from_spec(filename):
                     with specfile.tags(section) as tags:
                         if 'License' in tags:
                             result.append(tags.license.expanded_value)
-                except Exception:
+                except IndexError:
                     print(f"Warning: Could not parse section '{section.id}', skipping.")
     return result
 


### PR DESCRIPTION
Workaround for https://github.com/packit/specfile/issues/365

Tested on python3.15 specfile
```console
$ ./license-validate.py -v --spec python3.15.spec 
Warning: Could not parse section 'package -n %{pkgname}', skipping.
License: Python-2.0.1
Approved license
License: Python-2.0.1 AND MIT AND BSD-3-Clause AND MIT-CMU AND HPND-SMC AND BSD-2-Clause AND dtoa AND Apache-2.0 AND ISC
Approved license
License: Python-2.0.1 AND MIT
Approved license
License: Python-2.0.1 AND MIT AND Apache-2.0 AND (Apache-2.0 OR BSD-2-Clause)
Approved license
License: Python-2.0.1 AND MIT AND BSD-3-Clause AND MIT-CMU AND HPND-SMC AND BSD-2-Clause AND dtoa AND Apache-2.0 AND ISC
Approved license
License: Python-2.0.1 AND MIT AND BSD-3-Clause AND MIT-CMU AND HPND-SMC AND BSD-2-Clause AND dtoa AND Apache-2.0 AND ISC
Approved license
License: Python-2.0.1 AND MIT
Approved license
License: Python-2.0.1 AND MIT AND Apache-2.0 AND (Apache-2.0 OR BSD-2-Clause)
Approved license
License: Python-2.0.1 AND MIT AND BSD-3-Clause AND MIT-CMU AND HPND-SMC AND BSD-2-Clause AND dtoa AND Apache-2.0 AND ISC
Approved license
```

Closes #45 